### PR TITLE
Fix: typo in token request

### DIFF
--- a/token-endpoint-richiesta-token/request.rst
+++ b/token-endpoint-richiesta-token/request.rst
@@ -4,7 +4,10 @@ Request
 **Esempio di richiesta con authorization code (caso 1):**
 
 +-----------------------------------------------------------------------+
-|| *POST https://op.spid.agid.gov.it/token?*                            |
+|| *POST /token*                                                        |
+|| Host: op.spid.agid.gov.it                                            |
+|| Content-Type: application/x-www-form-urlencoded                      |
+||                                                                      |
 || **client_id**\ =https%3A%2F%2Frp.spid.agid.gov.it&                   |
 || **client_assertion**\ =eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWI  |
 | iOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNQSUQiLCJhZG1pbiI6dHJ1ZX0.LVyRDPVJm0S9 |
@@ -19,7 +22,10 @@ Request
 **Esempio di richiesta con refresh token (caso 2):**
 
 +-----------------------------------------------------------------------+
-|| *POST https://op.spid.agid.gov.it/token?*                            |
+|| *POST /token?*                                                       |
+|| Host: op.spid.agid.gov.it                                            |
+|| Content-Type: application/x-www-form-urlencoded                      |
+||                                                                      |
 || **client_id=**\ https%3A%2F%2Frp.spid.agid.gov.it&                   |
 || **client_assertion**\ =eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWI  |
 | iOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNQSUQiLCJhZG1pbiI6dHJ1ZX0.LVyRDPVJm0S9 |


### PR DESCRIPTION
## This PR

Fixes typo in token request

See https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication

## Note

@pdavide while working on https://github.com/italia/lg-modellointeroperabilita-docs we discovered the easier `list-table`  format https://github.com/italia/lg-modellointeroperabilita-docs/blame/master/doc/02_Pattern%20sicurezza/03_riferimenti-e-sigle.rst#L16 